### PR TITLE
Remove metrics endpoints from example.ini

### DIFF
--- a/example.ini
+++ b/example.ini
@@ -4,7 +4,7 @@ factory = reddit_service_activity:make_processor
 
 ; where to send metrics
 metrics.namespace = activity
-metrics.endpoint = localhost:8888
+metrics.endpoint =
 
 ; the redis server. the server must be running at least v2.8.9 and should
 ; be configured with the allkeys-lru eviction policy.
@@ -25,7 +25,7 @@ factory = reddit_service_activitygateway:make_wsgi_app
 
 ; where to send metrics
 metrics.namespace = activity_gateway
-metrics.endpoint = localhost:8888
+metrics.endpoint =
 
 ; where to find the thrift activity service
 activity.endpoint = localhost:9090


### PR DESCRIPTION
When doing test local installs, there's usually not a statsd server
running. Having these addresses specified in example.ini breaks the test
instance.

:eyeglasses: @bsimpson63 @KeyserSosa 
