### PR TITLE
Limit connection pool count

### DIFF
--- a/example.ini
+++ b/example.ini
@@ -10,6 +10,9 @@ metrics.endpoint =
 ; be configured with the allkeys-lru eviction policy.
 redis.url = redis://localhost:6379/0
 
+; how many open connections to allow to the redis server
+redis.max_connections = 100
+
 ; how long before a user's activity decays away and they no longer count
 ; towards that context's visitor count
 activity.window = 15 minutes

--- a/reddit_service_activity/__init__.py
+++ b/reddit_service_activity/__init__.py
@@ -89,7 +89,7 @@ def make_processor(app_config):  # pragma: nocover
     metrics_client = make_metrics_client(app_config)
     redis_pool = redis.BlockingConnectionPool.from_url(
         cfg.redis.url,
-        max_connections=100,
+        max_connections=cfg.redis.max_connections,
         timeout=0.1,
     )
 

--- a/reddit_service_activity/__init__.py
+++ b/reddit_service_activity/__init__.py
@@ -82,11 +82,16 @@ def make_processor(app_config):  # pragma: nocover
 
         "redis": {
             "url": config.String,
+            "max_connections": config.Optional(config.Integer, default=100),
         },
     })
 
     metrics_client = make_metrics_client(app_config)
-    redis_pool = redis.ConnectionPool.from_url(cfg.redis.url)
+    redis_pool = redis.BlockingConnectionPool.from_url(
+        cfg.redis.url,
+        max_connections=100,
+        timeout=0.1,
+    )
 
     baseplate = Baseplate()
     baseplate.configure_logging()


### PR DESCRIPTION
We've seen apps suddenly fill connection pools with tonnes of
connections causing redis to start complaining about too many open
connections.

Hypothesis: a redis response time spike occurs and during the slowness
more and more greenlets start opening new connections.

This should prevent flooding with open connections by enforcing a cap on
the number of connections in a pool.

:eyeglasses: @kjoconnor @dellis23 
