### PR TITLE
Add count_activity_multi for batch reads

### DIFF
--- a/reddit_service_activity/__init__.py
+++ b/reddit_service_activity/__init__.py
@@ -15,7 +15,7 @@ from .counter import ActivityCounter
 
 
 logger = logging.getLogger(__name__)
-_ID_RE = re.compile("^[A-Za-z0-9_]{,40}$")
+_ID_RE = re.compile("^[A-Za-z0-9_]{,50}$")
 _CACHE_TIME = 60  # seconds
 
 

--- a/reddit_service_activity/__init__.py
+++ b/reddit_service_activity/__init__.py
@@ -59,18 +59,45 @@ class Handler(ActivityService.ContextIface):
         self.counter.record_activity(context.redis, context_id, visitor_id)
 
     def count_activity(self, context, context_id):
-        if not _ID_RE.match(context_id):
+        results = self.count_activity_multi(context, [context_id])
+        return results[context_id]
+
+    def count_activity_multi(self, context, context_ids):
+        if not all(_ID_RE.match(context_id) for context_id in context_ids):
             raise ActivityService.InvalidContextIDException
 
-        cache_key = "{context}/cached".format(context=context_id)
-        cached_result = context.redis.get(cache_key)
-        if cached_result:
-            return ActivityInfo.from_json(cached_result.decode())
-        else:
-            count = self.counter.count_activity(context.redis, context_id)
-            info = ActivityInfo.from_count(self.fuzz_threshold, count)
-            context.redis.setex(cache_key, _CACHE_TIME, info.to_json())
-            return info
+        activity = {}
+
+        cache_keys = [context_id + "/cached" for context_id in context_ids]
+        cached_info = context.redis.mget(cache_keys)
+        for context_id, cached_value in zip(context_ids, cached_info):
+            if cached_value is None:
+                continue
+            activity[context_id] = ActivityInfo.from_json(cached_value.decode())
+
+        missing_ids = [id_ for id_ in context_ids if id_ not in activity]
+        if not missing_ids:
+            return activity
+
+        with context.redis.pipeline("count", transaction=False) as pipe:
+            for context_id in missing_ids:
+                self.counter.count_activity(pipe, context_id)
+            counts = pipe.execute()
+
+        to_cache = {}
+        for context_id, count in zip(missing_ids, counts):
+            if count is not None:
+                info = ActivityInfo.from_count(self.fuzz_threshold, count)
+                to_cache[context_id] = info
+        activity.update(to_cache)
+
+        if to_cache:
+            with context.redis.pipeline("cache", transaction=False) as pipe:
+                for context_id, count in to_cache.items():
+                    pipe.setex(context_id + "/cached", _CACHE_TIME, info.to_json())
+                pipe.execute()
+
+        return activity
 
 
 def make_processor(app_config):  # pragma: nocover

--- a/reddit_service_activity/activity.thrift
+++ b/reddit_service_activity/activity.thrift
@@ -53,4 +53,12 @@ service ActivityService extends baseplate.BaseplateService {
     */
     ActivityInfo count_activity(1: ContextID context_id)
         throws (1: InvalidContextIDException invalid_context_id),
+
+    /** Count how many visitors are active in a number of given contexts.
+
+    This is the same as `count_activity` but allows for querying in batch.
+
+    */
+    map<ContextID, ActivityInfo> count_activity_multi(1: list<ContextID> context_ids)
+        throws (1: InvalidContextIDException invalid_context_id),
 }


### PR DESCRIPTION
This will allow us to read multiple contexts (e.g. loggedin+loggedout, or whole batches of live threads in the cron job) at once. The backend operations to Redis are batched as well for great justice, using the newly minted redis pipeline support.

:eyeglasses: @dellis23 @kjoconnor 
