### PR TITLE
Fix mis-caching in count_activity_multi

### DIFF
--- a/reddit_service_activity/__init__.py
+++ b/reddit_service_activity/__init__.py
@@ -96,7 +96,7 @@ class Handler(ActivityService.ContextIface):
 
         if to_cache:
             with context.redis.pipeline("cache", transaction=False) as pipe:
-                for context_id, count in to_cache.items():
+                for context_id, info in to_cache.items():
                     pipe.setex(context_id + "/cached", _CACHE_TIME, info.to_json())
                 pipe.execute()
 


### PR DESCRIPTION
This was causing all contexts that needed to be cached in the same batch
to get the value of the last such context. I've also cleaned up the
tests and added one that specifically calls out this failure.

:eyeglasses: @bsimpson63 @ckwang8128 
