### PR TITLE
Utilize baseplate request tracing in activity gateway/service 

### DIFF
--- a/example.ini
+++ b/example.ini
@@ -20,6 +20,9 @@ activity.window = 15 minutes
 ; the minimum number of visitors in a context before fuzzing goes away
 activity.fuzz_threshold = 100
 
+; request tracing
+tracing.service_name = activity
+tracing.endpoint =
 
 ; an HTTP service which accepts pixel-like requests from browsers and records
 ; the users' activity with the thrift service.
@@ -29,6 +32,10 @@ factory = reddit_service_activitygateway:make_wsgi_app
 ; where to send metrics
 metrics.namespace = activity_gateway
 metrics.endpoint =
+
+; request tracing
+tracing.service_name = activity_gateway
+tracing.endpoint =
 
 ; where to find the thrift activity service
 activity.endpoint = localhost:9090

--- a/reddit_service_activity/__init__.py
+++ b/reddit_service_activity/__init__.py
@@ -109,7 +109,10 @@ def make_processor(app_config):  # pragma: nocover
             "window": config.Timespan,
             "fuzz_threshold": config.Integer,
         },
-
+        "tracing": {
+            "endpoint": config.Optional(config.Endpoint),
+            "service_name": config.String,
+        },
         "redis": {
             "url": config.String,
             "max_connections": config.Optional(config.Integer, default=100),
@@ -126,6 +129,10 @@ def make_processor(app_config):  # pragma: nocover
     baseplate = Baseplate()
     baseplate.configure_logging()
     baseplate.configure_metrics(metrics_client)
+    baseplate.configure_tracing(
+        cfg.tracing.service_name,
+        cfg.tracing.endpoint,
+    )
     baseplate.add_to_context("redis", RedisContextFactory(redis_pool))
 
     counter = ActivityCounter(cfg.activity.window.total_seconds())

--- a/reddit_service_activitygateway/__init__.py
+++ b/reddit_service_activitygateway/__init__.py
@@ -47,6 +47,10 @@ def make_wsgi_app(app_config):
         "activity": {
             "endpoint": config.Endpoint,
         },
+        "tracing": {
+            "endpoint": config.Optional(config.Endpoint),
+            "service_name": config.String,
+        },
     })
 
     metrics_client = make_metrics_client(app_config)
@@ -56,8 +60,13 @@ def make_wsgi_app(app_config):
     baseplate = Baseplate()
     baseplate.configure_logging()
     baseplate.configure_metrics(metrics_client)
+    baseplate.configure_tracing(
+        cfg.tracing.service_name,
+        cfg.tracing.endpoint,
+    )
+
     baseplate.add_to_context("activity",
-        ThriftContextFactory(pool, ActivityService.Client))
+                             ThriftContextFactory(pool, ActivityService.Client))
 
     configurator = Configurator(settings=app_config)
 

--- a/tests/gateway_tests.py
+++ b/tests/gateway_tests.py
@@ -45,6 +45,8 @@ class GatewayFunctionalTests(unittest.TestCase):
             "activity.endpoint": "/socket",
             "metrics.endpoint": "/socket",
             "metrics.namespace": "namespace",
+            "tracing.endpoint": None,
+            "tracing.service_name": "activity_gateway",
         })
 
         self.test_app = webtest.TestApp(app)


### PR DESCRIPTION
This enables basic span trace logging via Baseplate's tracing integration. 

:eyeglasses: @spladug 