### PR TITLE
Always fuzz activity counts, even at higher values

### DIFF
--- a/reddit_service_activity/__init__.py
+++ b/reddit_service_activity/__init__.py
@@ -21,11 +21,9 @@ _CACHE_TIME = 30  # seconds
 
 class ActivityInfo(ttypes.ActivityInfo):
     @classmethod
-    def from_count(cls, fuzz_threshold, count):
-        if count >= fuzz_threshold:
-            return cls(count=count, is_fuzzed=False)
-
-        decay = math.exp(float(-count) / 60)
+    def from_count(cls, count):
+        # keep a minimum jitter range of 5 for counts over 100
+        decay = math.exp(float(-min(count, 100)) / 60)
         jitter = round(5 * decay)
         return cls(count=count + random.randint(0, jitter), is_fuzzed=True)
 
@@ -45,8 +43,7 @@ class ActivityInfo(ttypes.ActivityInfo):
 
 
 class Handler(ActivityService.ContextIface):
-    def __init__(self, fuzz_threshold, counter):
-        self.fuzz_threshold = fuzz_threshold
+    def __init__(self, counter):
         self.counter = counter
 
     def is_healthy(self, context):
@@ -90,7 +87,7 @@ class Handler(ActivityService.ContextIface):
         to_cache = {}
         for context_id, count in zip(missing_ids, counts):
             if count is not None:
-                info = ActivityInfo.from_count(self.fuzz_threshold, count)
+                info = ActivityInfo.from_count(count)
                 to_cache[context_id] = info
         activity.update(to_cache)
 
@@ -107,7 +104,6 @@ def make_processor(app_config):  # pragma: nocover
     cfg = config.parse_config(app_config, {
         "activity": {
             "window": config.Timespan,
-            "fuzz_threshold": config.Integer,
         },
 
         "redis": {
@@ -129,10 +125,7 @@ def make_processor(app_config):  # pragma: nocover
     baseplate.add_to_context("redis", RedisContextFactory(redis_pool))
 
     counter = ActivityCounter(cfg.activity.window.total_seconds())
-    handler = Handler(
-        fuzz_threshold=cfg.activity.fuzz_threshold,
-        counter=counter,
-    )
+    handler = Handler(counter=counter)
     processor = ActivityService.ContextProcessor(handler)
     event_handler = BaseplateProcessorEventHandler(logger, baseplate)
     processor.setEventHandler(event_handler)

--- a/tests/activity_tests.py
+++ b/tests/activity_tests.py
@@ -11,23 +11,25 @@ from reddit_service_activity.activity_thrift import ActivityService
 
 
 class ActivityInfoTests(unittest.TestCase):
-    def test_fuzzed_if_small(self):
+    def test_always_fuzzed(self):
         with mock.patch("random.randint") as randint:
             randint.return_value = 3
-            info = activity.ActivityInfo.from_count(fuzz_threshold=100, count=99)
+            info = activity.ActivityInfo.from_count(count=99)
         self.assertEqual(info.count, 102)
         self.assertTrue(info.is_fuzzed)
 
-    def test_not_fuzzed_if_large(self):
-        info = activity.ActivityInfo.from_count(fuzz_threshold=100, count=101)
-        self.assertEqual(info.count, 101)
-        self.assertFalse(info.is_fuzzed)
-
     def test_range_of_fuzzing(self):
-        samples = [activity.ActivityInfo.from_count(fuzz_threshold=100, count=10).count
+        samples = [activity.ActivityInfo.from_count(count=10).count
                    for i in range(1000)]
         self.assertTrue(all(sample >= 10 for sample in samples))
-        self.assertTrue(all(sample <= 15 for sample in samples))
+        self.assertTrue(all(sample <= 14 for sample in samples))
+        self.assertTrue(any(sample != 10 for sample in samples))
+
+        samples = [activity.ActivityInfo.from_count(count=1000).count
+                   for i in range(1000)]
+        self.assertTrue(all(sample >= 1000 for sample in samples))
+        self.assertTrue(all(sample <= 1005 for sample in samples))
+        self.assertTrue(any(sample != 1000 for sample in samples))
 
     def test_json_roundtrip(self):
         info = activity.ActivityInfo(count=42, is_fuzzed=True)
@@ -47,10 +49,7 @@ class MockActivityInfo(activity.ActivityInfo):
 class ActivityServiceTests(unittest.TestCase):
     def setUp(self):
         self.mock_counter = mock.Mock(spec=ActivityCounter)
-        self.handler = activity.Handler(
-            fuzz_threshold=10,
-            counter=self.mock_counter,
-        )
+        self.handler = activity.Handler(counter=self.mock_counter)
         self.mock_context = mock.Mock()
 
         redis_ = mock.Mock(spec=redis.StrictRedis)
@@ -98,23 +97,27 @@ class ActivityServiceTests(unittest.TestCase):
         self.mock_context.redis.mget.return_value = [None]
 
         self.mock_pipe.execute.return_value = [125]
-        result = self.handler.count_activity(self.mock_context, "context")
+        with mock.patch("random.randint") as randint:
+            randint.return_value = 3
+            result = self.handler.count_activity(self.mock_context, "context")
 
         self.mock_context.redis.mget.assert_called_with(["context/cached"])
-        self.assertEqual(result.count, 125)
-        self.assertFalse(result.is_fuzzed)
+        self.assertEqual(result.count, 128)
+        self.assertTrue(result.is_fuzzed)
 
         # 30 is how long we cache for.
-        self.mock_pipe.setex.assert_called_with("context/cached", 30, (125, False))
+        self.mock_pipe.setex.assert_called_with("context/cached", 30, (128, True))
 
     @mock.patch("reddit_service_activity.ActivityInfo", new=MockActivityInfo)
     def test_count_activity_multi_cache_miss(self):
         self.mock_context.redis.mget.return_value = [None, None]
         self.mock_pipe.execute.return_value = [500, 600]
 
-        self.handler.count_activity_multi(self.mock_context, ["one", "two"])
+        with mock.patch("random.randint") as randint:
+            randint.return_value = 0
+            self.handler.count_activity_multi(self.mock_context, ["one", "two"])
 
         self.mock_pipe.setex.assert_has_calls([
-            mock.call("one/cached", 30, (500, False)),
-            mock.call("two/cached", 30, (600, False)),
+            mock.call("one/cached", 30, (500, True)),
+            mock.call("two/cached", 30, (600, True)),
         ], any_order=True)


### PR DESCRIPTION
Jesse Ruderman reported that by maintaining a stable number of bots in a
given subreddit, the fuzzing can be subverted to determine when a
specific targeted user is directed to that subreddit. We could boost the
fuzzing threshold to a less feasibly mimiced count, but there's little
value in the number being super precise.
