### PR TITLE
Fix crash when count_multi gets empty list in request

### DIFF
--- a/reddit_service_activity/__init__.py
+++ b/reddit_service_activity/__init__.py
@@ -66,6 +66,9 @@ class Handler(ActivityService.ContextIface):
         return results[context_id]
 
     def count_activity_multi(self, context, context_ids):
+        if not context_ids:
+            return {}
+
         if not all(_ID_RE.match(context_id) for context_id in context_ids):
             raise ActivityService.InvalidContextIDException
 

--- a/tests/activity_tests.py
+++ b/tests/activity_tests.py
@@ -121,3 +121,7 @@ class ActivityServiceTests(unittest.TestCase):
             mock.call("one/cached", 30, (500, True)),
             mock.call("two/cached", 30, (600, True)),
         ], any_order=True)
+
+    def test_count_activity_multi_empty_list(self):
+        result = self.handler.count_activity_multi(self.mock_context, [])
+        self.assertEqual(result, {})


### PR DESCRIPTION
This would translate into a degenerate command to redis and then the
request would crash. Now we just short-circuit and return an empty dict.

This fixes IO-1968. Fix for r2 generating these spurious requests coming shortly.